### PR TITLE
Provide static members required by NIST's RI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.classpath
+.project
+.settings/
+target/

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.opentelecoms.sdp</groupId>
   <artifactId>sdp-api</artifactId>
-  <version>1.0</version>
+  <version>1.0.1</version>
   <packaging>bundle</packaging>
 
   <name>sdp-api</name>

--- a/src/main/java/javax/sdp/SdpFactory.java
+++ b/src/main/java/javax/sdp/SdpFactory.java
@@ -19,78 +19,83 @@ import java.net.URL;
 import java.util.Date;
 import java.util.Vector;
 
-public interface SdpFactory {
+public abstract class SdpFactory {
 
-	SessionDescription createSessionDescription() throws SdpException;
+	public abstract SessionDescription createSessionDescription() throws SdpException;
 
-	SessionDescription createSessionDescription(String s)
+	public abstract SessionDescription createSessionDescription(String s)
 			throws SdpParseException;
 
-	BandWidth createBandwidth(String modifier, int value);
+	public abstract BandWidth createBandwidth(String modifier, int value);
 
-	Attribute createAttribute(String name, String value);
+	public abstract Attribute createAttribute(String name, String value);
 
-	Info createInfo(String value);
+	public abstract Info createInfo(String value);
 
-	Phone createPhone(String value);
+	public abstract Phone createPhone(String value);
 
-	EMail createEMail(String value);
+	public abstract EMail createEMail(String value);
 
-	URI createURI(URL value) throws SdpException;
+	public abstract URI createURI(URL value) throws SdpException;
 
-	SessionName createSessionName(String name);
+	public abstract SessionName createSessionName(String name);
 
-	Key createKey(String method, String key);
+	public abstract Key createKey(String method, String key);
 
-	Version createVersion(int value);
+	public abstract Version createVersion(int value);
 
-	Media createMedia(String media, int port, int numPorts, String transport,
+	public abstract Media createMedia(String media, int port, int numPorts, String transport,
 			Vector staticRtpAvpTypes) throws SdpException;
 
-	Origin createOrigin(String userName, String address) throws SdpException;
+	public abstract Origin createOrigin(String userName, String address) throws SdpException;
 
-	Origin createOrigin(String userName, long sessionId, long sessionVersion,
+	public abstract Origin createOrigin(String userName, long sessionId, long sessionVersion,
 			String networkType, String addrType, String address)
 			throws SdpException;
 
-	MediaDescription createMediaDescription(String media, int port,
+	public abstract MediaDescription createMediaDescription(String media, int port,
 			int numPorts, String transport, int[] staticRtpAvpTypes)
 			throws IllegalArgumentException, SdpException;
 
-	MediaDescription createMediaDescription(String media, int port,
+	public abstract MediaDescription createMediaDescription(String media, int port,
 			int numPorts, String transport, String[] formats);
 
-	TimeDescription createTimeDescription(Time t) throws SdpException;
+	public abstract TimeDescription createTimeDescription(Time t) throws SdpException;
 
-	TimeDescription createTimeDescription() throws SdpException;
+	public abstract TimeDescription createTimeDescription() throws SdpException;
 
-	TimeDescription createTimeDescription(Date start, Date stop)
+	public abstract TimeDescription createTimeDescription(Date start, Date stop)
 			throws SdpException;
 
-	String formatMulticastAddress(String addr, int ttl, int numAddrs);
+	public abstract String formatMulticastAddress(String addr, int ttl, int numAddrs);
 
-	Connection createConnection(String netType, String addrType, String addr,
+	public abstract Connection createConnection(String netType, String addrType, String addr,
 			int ttl, int numAddrs) throws SdpException;
 
-	Connection createConnection(String netType, String addrType, String addr)
+	public abstract Connection createConnection(String netType, String addrType, String addr)
 			throws SdpException;
 
-	Connection createConnection(String addr, int ttl, int numAddrs)
+	public abstract Connection createConnection(String addr, int ttl, int numAddrs)
 			throws SdpException;
 
-	Connection createConnection(String addr) throws SdpException;
+	public abstract Connection createConnection(String addr) throws SdpException;
 
-	Time createTime(Date start, Date stop) throws SdpException;
+	public abstract Time createTime(Date start, Date stop) throws SdpException;
 
-	Time createTime() throws SdpException;
+	public abstract Time createTime() throws SdpException;
 
-	RepeatTime createRepeatTime(int repeatInterval, int activeDuration,
+	public abstract RepeatTime createRepeatTime(int repeatInterval, int activeDuration,
 			int[] offsets);
 
-	TimeZoneAdjustment createTimeZoneAdjustment(Date d, int offset);
+	public abstract TimeZoneAdjustment createTimeZoneAdjustment(Date d, int offset);
 
-	Date getDateFromNtp(long ntpTime);
+	public static Date getDateFromNtp(long ntpTime) {
+		return new Date((ntpTime - SdpConstants.NTP_CONST) * 1000);
+	}
 
-	long getNtpTime(Date d) throws SdpParseException;
-
+	public static long getNtpTime(Date d) throws SdpParseException {
+		if (d == null)
+			return -1;
+		return ((d.getTime() / 1000) + SdpConstants.NTP_CONST);
+	}
 }


### PR DESCRIPTION
See #1 for details. It goes along with [java-sdp-nist-bridge](https://github.com/ibauersachs/java-sdp-nist-bridge) and makes e.g. ice4j dsfg-packable.
The bridge package can be hosted at Opentelecoms or Jitsi. Any preference? (Same goes for a fork of the NIST RI repo to provide a dsfg build).
